### PR TITLE
Update C++ trending url

### DIFF
--- a/colors.json
+++ b/colors.json
@@ -297,7 +297,7 @@
     },
     "C++": {
         "color": "#f34b7d",
-        "url": "https://github.com/trending?l=C++"
+        "url": "https://github.com/trending?l=Cpp"
     },
     "C2hs Haskell": {
         "color": null,


### PR DESCRIPTION
`https://github.com/trending?l=C++` doesn't show any results   
`https://github.com/trending?l=Cpp` shows trending as intended   